### PR TITLE
Add header support

### DIFF
--- a/admmonkit/monkit.go
+++ b/admmonkit/monkit.go
@@ -29,6 +29,9 @@ type Options struct {
 
 	// ProtoOps allows you to set protocol options.
 	ProtoOpts admproto.Options
+
+	// Headers allow you to set arbitrary key/value pairs to be included in each packet send
+	Headers map[string]string
 }
 
 // Send will push all of the metrics in the registry to the address with the
@@ -70,9 +73,12 @@ func Send(ctx context.Context, opts Options) (err error) {
 			// always ensure the buffer has the prefix in it.
 			if len(buf) == 0 {
 				// if we can't add the application and instance id, it's fatal.
-				buf, err = w.Begin(buf, opts.Application, opts.InstanceId)
+				buf, err = w.Begin(buf, opts.Application, opts.InstanceId, len(opts.Headers))
 				if err != nil {
 					return
+				}
+				for key, value := range opts.Headers {
+					buf, err = w.AppendHeader(buf, []byte(key), []byte(value))
 				}
 			}
 

--- a/admmonkit/monkit.go
+++ b/admmonkit/monkit.go
@@ -79,6 +79,9 @@ func Send(ctx context.Context, opts Options) (err error) {
 				}
 				for key, value := range opts.Headers {
 					buf, err = w.AppendHeader(buf, []byte(key), []byte(value))
+					if err != nil {
+						return
+					}
 				}
 			}
 

--- a/admproto/fuzz.go
+++ b/admproto/fuzz.go
@@ -6,7 +6,7 @@ func Fuzz(data []byte) int {
 	var r Reader
 	var err error
 
-	data, _, _, err = r.Begin(data)
+	data, _, _, _, err = r.Begin(data)
 	if err != nil {
 		return 0
 	}

--- a/admproto/fuzz_gen.go
+++ b/admproto/fuzz_gen.go
@@ -15,7 +15,7 @@ func main() {
 	for {
 		var w admproto.Writer
 		buf = buf[:0]
-		buf, _ = w.Begin(buf, "app", []byte("ins"))
+		buf, _ = w.Begin(buf, "app", []byte("ins"), 0)
 		values := rand.Intn(10)
 		for i := 0; i < values; i++ {
 			buf, _ = w.Append(buf, string(randomValue()), rand.Float64())

--- a/admproto/proto_test.go
+++ b/admproto/proto_test.go
@@ -51,9 +51,7 @@ func TestReaderWriter(t *testing.T) {
 		var header_key, header_value []byte
 		for i := 0; i < num_headers; i++ {
 			buf, header_key, header_value, err = r.NextHeader(buf)
-			if err != nil {
-				t.Fatal("err reading key", err)
-			}
+			assertNoError(t, err)
 			headers[string(header_key)] = string(header_value)
 		}
 		if !reflect.DeepEqual(expected_headers, headers) {

--- a/admproto/proto_test.go
+++ b/admproto/proto_test.go
@@ -1,6 +1,9 @@
 package admproto
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func assertNoError(t *testing.T, err error) {
 	t.Helper()
@@ -10,7 +13,7 @@ func assertNoError(t *testing.T, err error) {
 }
 
 func TestReaderWriter(t *testing.T) {
-	runTest := func(t *testing.T, options Options) {
+	runTest := func(t *testing.T, options Options, expected_headers map[string]string) {
 		var (
 			buf []byte
 			r   Reader
@@ -18,8 +21,12 @@ func TestReaderWriter(t *testing.T) {
 			err error
 		)
 
-		buf, err = w.Begin(buf, "testapp", []byte("ins-id"))
+		buf, err = w.Begin(buf, "testapp", []byte("ins-id"), len(expected_headers))
 		assertNoError(t, err)
+		for key, value := range expected_headers {
+			buf, err = w.AppendHeader(buf, []byte(key), []byte(value))
+			assertNoError(t, err)
+		}
 		buf, err = w.Append(buf, "hello", 0)
 		assertNoError(t, err)
 		buf, err = w.Append(buf, "hello.world", 1)
@@ -31,10 +38,26 @@ func TestReaderWriter(t *testing.T) {
 
 		t.Logf("%x", buf)
 
-		buf, application, ins_id, err := r.Begin(buf)
+		buf, application, ins_id, num_headers, err := r.Begin(buf)
 		assertNoError(t, err)
 		if string(application) != "testapp" || string(ins_id) != "ins-id" {
 			t.Fatal("failed on begin")
+		}
+
+		var headers map[string]string
+		if num_headers > 0 {
+			headers = make(map[string]string, num_headers)
+		}
+		var header_key, header_value []byte
+		for i := 0; i < num_headers; i++ {
+			buf, header_key, header_value, err = r.NextHeader(buf)
+			if err != nil {
+				t.Fatal("err reading key", err)
+			}
+			headers[string(header_key)] = string(header_value)
+		}
+		if !reflect.DeepEqual(expected_headers, headers) {
+			t.Fatal("headers not as expected")
 		}
 
 		buf, key, value, err := r.Next(buf)
@@ -67,12 +90,20 @@ func TestReaderWriter(t *testing.T) {
 	}
 
 	t.Run("Float16", func(t *testing.T) {
-		runTest(t, Options{FloatEncoding: Float16Encoding})
+		runTest(t, Options{FloatEncoding: Float16Encoding},
+			map[string]string{
+				"asfd": "a",
+				"qwer": "b",
+			})
+
 	})
 	t.Run("Float32", func(t *testing.T) {
-		runTest(t, Options{FloatEncoding: Float32Encoding})
+		runTest(t, Options{FloatEncoding: Float32Encoding},
+			map[string]string{
+				"asfd": "a",
+			})
 	})
 	t.Run("Float64", func(t *testing.T) {
-		runTest(t, Options{FloatEncoding: Float64Encoding})
+		runTest(t, Options{FloatEncoding: Float64Encoding}, nil)
 	})
 }

--- a/admproto/writer.go
+++ b/admproto/writer.go
@@ -29,14 +29,18 @@ func (w *Writer) Reset() {
 }
 
 // Begin appends header information to the buffer.
-func (w *Writer) Begin(in []byte, application string, instance_id []byte) (
+func (w *Writer) Begin(in []byte, application string, instance_id []byte, num_headers int) (
 	out []byte, err error) {
 
+	// Check that length does not exceed 255 so we can encode the length in a single byte
 	if len(application) > 255 {
 		return nil, Error.New("application too long")
 	}
 	if len(instance_id) > 255 {
 		return nil, Error.New("instance_id too long")
+	}
+	if num_headers > 255 {
+		return nil, Error.New("too many headers")
 	}
 
 	var version byte
@@ -54,7 +58,11 @@ func (w *Writer) Begin(in []byte, application string, instance_id []byte) (
 	}
 
 	// we do not send headers yet
-	version |= headersExcluded
+	if num_headers > 0 {
+		version |= headersIncluded
+	} else {
+		version |= headersExcluded
+	}
 
 	in = append(in, version)
 	in = append(in, byte(len(application)))
@@ -62,6 +70,25 @@ func (w *Writer) Begin(in []byte, application string, instance_id []byte) (
 	in = append(in, byte(len(instance_id)))
 	in = append(in, instance_id...)
 
+	if num_headers > 0 {
+		in = append(in, byte(num_headers))
+	}
+
+	return in, nil
+}
+
+// AppendHeader adds the key and value to the starting bytes of the packet
+func (w *Writer) AppendHeader(in, key, value []byte) (out []byte, err error) {
+	if len(key) > 255 {
+		return nil, Error.New("header key %s too long", key)
+	}
+	if len(value) > 255 {
+		return nil, Error.New("header value %s too long", value)
+	}
+	in = append(in, byte(len(key)))
+	in = append(in, key...)
+	in = append(in, byte(len(value)))
+	in = append(in, value...)
 	return in, nil
 }
 


### PR DESCRIPTION
Add the ability to set arbitrary tag-name and value pairs when writing
to the buffer. Each tag and value is written to the header of the
buffer.